### PR TITLE
add color configuration option

### DIFF
--- a/example/editor/elm-package.json
+++ b/example/editor/elm-package.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0"
+        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
+        "eskimoblood/elm-color-extra": "3.0.4 <= v < 4.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/rainbow/LICENSE
+++ b/example/rainbow/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Damien Klinnert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/example/rainbow/elm-package.json
+++ b/example/rainbow/elm-package.json
@@ -1,19 +1,19 @@
 {
-    "version": "2.0.2",
-    "summary": "A highly configurable, efficiently rendered spinner component",
+    "version": "1.0.0",
+    "summary": "elm-spinner rainbow example",
     "repository": "https://github.com/damienklinnert/elm-spinner.git",
     "license": "MIT",
     "source-directories": [
-        "src"
+        "src",
+        "../../src"
     ],
     "exposed-modules": [
-        "Spinner"
     ],
     "dependencies": {
+        "eskimoblood/elm-color-extra": "3.0.4 <= v < 4.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
-        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
-        "eskimoblood/elm-color-extra": "3.0.4 <= v < 4.0.0"
+        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/rainbow/src/Main.elm
+++ b/example/rainbow/src/Main.elm
@@ -1,0 +1,95 @@
+module Main exposing (..)
+
+import Html
+import Html.Attributes exposing (style)
+import Html.App exposing (program)
+import Color exposing (Color, rgb)
+import Color.Gradient exposing (gradient)
+import Color.Interpolate exposing (Space(RGB))
+import Spinner exposing (Direction(..))
+
+
+type Msg
+    = Noop
+    | SpinnerMsg Spinner.Msg
+
+
+type alias Model =
+    { spinner : Spinner.Model
+    }
+
+
+main : Program Never
+main =
+    program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = (\model -> Sub.map SpinnerMsg Spinner.subscription)
+        }
+
+
+init : ( Model, Cmd Msg )
+init =
+    { spinner = Spinner.init } ! []
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Noop ->
+            model ! []
+
+        SpinnerMsg msg ->
+            let
+                spinnerModel =
+                    Spinner.update msg model.spinner
+            in
+                { model | spinner = spinnerModel } ! []
+
+
+palette : List Color
+palette =
+  [ Color.green
+  , Color.lightGreen
+  , Color.lightYellow
+  , Color.red
+  , Color.purple
+  , Color.lightBlue
+  , Color.blue
+  ]
+
+
+rainbowGradient : List Color
+rainbowGradient =
+  gradient RGB palette 13
+
+
+rainbowColor : Float -> Color
+rainbowColor n =
+  Maybe.withDefault Color.white (List.head (List.drop (floor n % 13) rainbowGradient))
+
+
+config =
+  { color = rainbowColor
+  , lines = 13
+  , length = 0
+  , width = 36
+  , radius = 6
+  , scale = 0.75
+  , corners = 1
+  , opacity = 0.05
+  , rotate = 23
+  , direction = Clockwise
+  , speed = 1
+  , trail = 100
+  , translateX = 50
+  , translateY = 50
+  , shadow = False
+  , hwaccel = False
+  }
+
+
+view : Model -> Html.Html Msg
+view model =
+    Html.div [] [ Spinner.view config model.spinner ]

--- a/example/simple/elm-package.json
+++ b/example/simple/elm-package.json
@@ -10,6 +10,7 @@
     "exposed-modules": [
     ],
     "dependencies": {
+        "eskimoblood/elm-color-extra": "3.0.4 <= v < 4.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0",
         "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0"

--- a/src/Spinner.elm
+++ b/src/Spinner.elm
@@ -14,6 +14,8 @@ Check the [README for a general introduction into this module](http://package.el
 import Html exposing (Html, div)
 import Html.Attributes exposing (style)
 import Time exposing (Time)
+import Color exposing (Color, white)
+import Color.Convert exposing (colorToCssRgba)
 import AnimationFrame exposing (times)
 
 
@@ -88,6 +90,7 @@ type Direction
  - `translateY`: moves the spinner vertically (a value from 0 to 100, default is 50)
  - `shadow`: adds a box shadow (default is True)
  - `hwaccel`: enables hardware acceleration for lines (default is False)
+ - `color`: determines the color for each line based on an index parameter (default is `always Color.white`)
 
 -}
 type alias Config =
@@ -106,6 +109,7 @@ type alias Config =
     , translateY : Float
     , shadow : Bool
     , hwaccel : Bool
+    , color : Float -> Color
     }
 
 
@@ -128,6 +132,7 @@ defaultConfig =
     , translateY = 50
     , shadow = True
     , hwaccel = False
+    , color = always white
     }
 
 
@@ -184,7 +189,7 @@ barStyles cfg time n =
             max cfg.opacity trailedOpacity |> toString
     in
         style
-            [ ( "background", "#fff" )
+            [ ( "background", colorToCssRgba (cfg.color n) )
             , ( "height", (toString (cfg.width * cfg.scale)) ++ "px" )
             , ( "width", "" ++ (toString (cfg.length * cfg.scale + cfg.width)) ++ "px" )
             , ( "position", "absolute" )


### PR DESCRIPTION
Adds a configuration option to give the lines separate colors, like in this example:

![rainbow-spinner](https://cloud.githubusercontent.com/assets/2677165/17734960/e2bc3d96-64c2-11e6-9396-4ca2d5e6a2ed.gif)

Also adds a new dependency to convert between elm `Color` and css rgba strings, but we can also inline that logic if you feel you don't want to introduce a dependency just for that.

Btw: Is there a reason the `i`/`n` variables are floats? It looks like they could be discrete integers instead. Maybe something worth fixing if they'd be part of the API now? Happy to do that in the same PR if you want, or a different one. 
