### PR TITLE
Fix #9 so scale effects all properties uniformly.

### DIFF
--- a/src/Spinner.elm
+++ b/src/Spinner.elm
@@ -149,13 +149,16 @@ outerStyle cfg =
         ([ ( "position", "absolute" )
          , ( "top", "calc(" ++ (toString cfg.translateY) ++ "%)" )
          , ( "left", (toString cfg.translateX) ++ "%" )
-         , ( "transform", "scale(" ++ toString cfg.scale ++ ")" )
+         , ( "transform"
+           , "scale("
+                ++ toString cfg.scale
+                ++ ")"
+                ++ if cfg.hwaccel then
+                    " translate3d(0px, 0px, 0px)"
+                   else
+                    ""
+           )
          ]
-            ++ (if cfg.hwaccel then
-                    [ ( "transform", "translate3d(0px, 0px, 0px)" ) ]
-                else
-                    []
-               )
         )
 
 

--- a/src/Spinner.elm
+++ b/src/Spinner.elm
@@ -149,6 +149,7 @@ outerStyle cfg =
         ([ ( "position", "absolute" )
          , ( "top", "calc(" ++ (toString cfg.translateY) ++ "%)" )
          , ( "left", (toString cfg.translateX) ++ "%" )
+         , ( "transform", "scale(" ++ toString cfg.scale ++ ")" )
          ]
             ++ (if cfg.hwaccel then
                     [ ( "transform", "translate3d(0px, 0px, 0px)" ) ]
@@ -193,12 +194,12 @@ barStyles cfg time n =
     in
         style
             [ ( "background", colorToCssRgba (cfg.color n) )
-            , ( "height", (toString (cfg.width * cfg.scale)) ++ "px" )
-            , ( "width", "" ++ (toString (cfg.length * cfg.scale + cfg.width)) ++ "px" )
+            , ( "height", (toString cfg.width) ++ "px" )
+            , ( "width", "" ++ (toString (cfg.length + cfg.width)) ++ "px" )
             , ( "position", "absolute" )
             , ( "transform-origin", "left" )
-            , ( "transform", "rotate(" ++ deg ++ "deg) translate(" ++ (toString (cfg.radius * cfg.scale)) ++ "px, 0px)" )
-            , ( "border-radius", (toString (borderRadius * cfg.scale)) ++ "px" )
+            , ( "transform", "rotate(" ++ deg ++ "deg) translate(" ++ (toString cfg.radius) ++ "px, 0px)" )
+            , ( "border-radius", (toString borderRadius) ++ "px" )
             , ( "opacity", baseLinedOpacity )
             , ( "box-shadow"
               , (if cfg.shadow then


### PR DESCRIPTION
Using the CSS scale made for more consistent scaling of the drop shadow, which didn't look consistent just using `"0 0 " ++ (toString (4 * cfg.scale)) ++ "px #000"`