### PR TITLE
Backport code that supports Elm 0.18

### DIFF
--- a/0.18-src/Spinner.elm
+++ b/0.18-src/Spinner.elm
@@ -1,0 +1,234 @@
+module Spinner exposing
+    ( Model, Msg, subscription, init, update, view
+    , Direction(..), Config, defaultConfig
+    )
+
+{-| A highly configurable, efficiently rendered spinner component.
+
+Check the [README for a general introduction into this module](http://package.elm-lang.org/packages/damienklinnert/elm-spinner/latest/).
+
+
+# The Elm Architecture
+
+@docs Model, Msg, subscription, init, update, view
+
+
+# Custom Spinners
+
+@docs Direction, Config, defaultConfig
+
+-}
+
+import AnimationFrame exposing (times)
+import Color exposing (Color, white)
+import Color.Convert exposing (colorToCssRgba)
+import Html exposing (Html, div)
+import Html.Attributes exposing (style)
+import Time exposing (Time)
+
+
+{-| Contains the current state for the spinner.
+-}
+type Model
+    = Model Time
+
+
+{-| `Msg` messages need to be passed through your application.
+-}
+type Msg
+    = Noop
+    | AnimationFrame Time
+
+
+{-| Add this to your `program`s subscriptions to animate the spinner.
+-}
+subscription : Sub Msg
+subscription =
+    times AnimationFrame
+
+
+{-| Defines an initial value for the `Model` type.
+-}
+init : Model
+init =
+    Model 0
+
+
+{-| Accepts `Msg` and `Model` and computes a new `Model`.
+-}
+update : Msg -> Model -> Model
+update msg (Model time) =
+    case msg of
+        Noop ->
+            Model time
+
+        AnimationFrame newTime ->
+            Model newTime
+
+
+{-| The actual spinner component.
+-}
+view : Config -> Model -> Html msg
+view cfg (Model time) =
+    let
+        range =
+            List.range 0 (floor cfg.lines - 1) |> List.map toFloat
+    in
+    div []
+        (List.map (\i -> div [ outerStyle cfg ] [ div [ barStyles cfg time i ] [] ]) range)
+
+
+{-| A spinner can spin `Clockwise` or `Counterclockwise`.
+-}
+type Direction
+    = Clockwise
+    | Counterclockwise
+
+
+{-| A type describing how your spinner looks like.
+
+  - `lines`: Number of lines (a value from 5 to 17, default is 13)
+  - `length`: line length (a value from 0 to 56, default is 28)
+  - `width`: line width (a value from 2 to 52, default is 14)
+  - `radius`: distance from origin to beginning of lines (a value from 0 to 84, default is 42)
+  - `scale`: scale for the whole spinner (a value from 0 to 5, default is 1)
+  - `corners`: roundness of corners (a value from 0 to 1, default is 1)
+  - `opacity`: minimum opacity of inactive lines (a value from 0 to 1, default is 0.25)
+  - `rotate`: rotate the spinner by some degrees (a value from 0 to 90, default is 0)
+  - `direction`: spinner direction (default is Clockwise)
+  - `speed`: (a value from 0.5 (slowest), 2.2 (fastest), default is 1)
+  - `trail`: how long is the trail after the active line (a value from 10 to 100, default is 60)
+  - `translateX`: moves the spinner horizontally (a value from 0 to 100, default is 50)
+  - `translateY`: moves the spinner vertically (a value from 0 to 100, default is 50)
+  - `shadow`: adds a box shadow (default is True)
+  - `hwaccel`: enables hardware acceleration for lines (default is False)
+  - `color`: determines the color for each line based on an index parameter (default is `always Color.white`)
+
+-}
+type alias Config =
+    { lines : Float
+    , length : Float
+    , width : Float
+    , radius : Float
+    , scale : Float
+    , corners : Float
+    , opacity : Float
+    , rotate : Float
+    , direction : Direction
+    , speed : Float
+    , trail : Float
+    , translateX : Float
+    , translateY : Float
+    , shadow : Bool
+    , hwaccel : Bool
+    , color : Float -> Color
+    }
+
+
+{-| A default spinner for use in your application.
+-}
+defaultConfig : Config
+defaultConfig =
+    { lines = 13
+    , length = 28
+    , width = 14
+    , radius = 42
+    , scale = 1
+    , corners = 1
+    , opacity = 0.25
+    , rotate = 0
+    , direction = Clockwise
+    , speed = 1
+    , trail = 60
+    , translateX = 50
+    , translateY = 50
+    , shadow = True
+    , hwaccel = False
+    , color = always white
+    }
+
+
+
+-- Helpers, those make our spinner look like one
+
+
+outerStyle : Config -> Html.Attribute msg
+outerStyle cfg =
+    style
+        [ ( "position", "absolute" )
+        , ( "top", "calc(" ++ toString cfg.translateY ++ "%)" )
+        , ( "left", toString cfg.translateX ++ "%" )
+        , ( "transform"
+          , "scale("
+                ++ toString cfg.scale
+                ++ ")"
+                ++ (if cfg.hwaccel then
+                        " translate3d(0px, 0px, 0px)"
+
+                    else
+                        ""
+                   )
+          )
+        ]
+
+
+barStyles : Config -> Float -> Float -> Html.Attribute a
+barStyles cfg time n =
+    let
+        directionBasedDeg =
+            if cfg.direction == Clockwise then
+                cfg.lines - n
+
+            else
+                n
+
+        deg =
+            360 / cfg.lines * directionBasedDeg + cfg.rotate |> toString
+
+        fullBlinkTime =
+            1000 / cfg.speed
+
+        scaledTrail =
+            ceiling (cfg.lines * cfg.trail / 100) |> toFloat
+
+        movePerLight =
+            (n / cfg.lines) * fullBlinkTime |> truncate
+
+        lineOpacity =
+            toFloat (1000 - ((truncate time + movePerLight) % truncate fullBlinkTime)) / 1000
+
+        trailedOpacity =
+            max 0 ((cfg.lines * lineOpacity) - (cfg.lines - scaledTrail)) / scaledTrail
+
+        borderRadius =
+            cfg.corners * cfg.width / 2
+
+        baseLinedOpacity =
+            max cfg.opacity trailedOpacity |> toString
+    in
+    style
+        [ ( "background", colorToCssRgba (cfg.color n) )
+        , ( "height", toString cfg.width ++ "px" )
+        , ( "width", "" ++ toString (cfg.length + cfg.width) ++ "px" )
+        , ( "position", "absolute" )
+        , ( "transform-origin", "left" )
+        , ( "transform", "rotate(" ++ deg ++ "deg) translate(" ++ toString cfg.radius ++ "px, 0px)" )
+        , ( "border-radius", toString borderRadius ++ "px" )
+        , ( "opacity", baseLinedOpacity )
+        , ( "box-shadow"
+          , if cfg.shadow then
+                "0 0 4px #000"
+
+            else
+                "none"
+          )
+
+        -- TODO add browser prefixes!
+        , ( "-webkit-box-shadow"
+          , if cfg.shadow then
+                "0 0 4px #000"
+
+            else
+                "none"
+          )
+        ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,7 @@
 ### Changed
 - Update package to work with Elm 0.19. 
 - Use `Color` package created for Elm 0.19, [avh4/elm-color](https://package.elm-lang.org/packages/avh4/elm-color/latest/), which replaces the previous [elm/color](https://github.com/elm/color) package used pre-Elm 0.19.
-
-### Removed
-- Support for Elm 0.18.
-- Dependency on package [eskimoblood/elm-color-extra](https://github.com/eskimoblood/elm-color-extra). That package provided a `Color.Convert.colorToCssRgba` function used when rendering the spinner HTML. The new `Color` package provides equivalent functionality directly with `Color.toCssString`.
+- Backport code that works with Elm 0.18. This is meant to smooth the transition for clients in the early days of Elm 0.19. Support for Elm 0.18 should be dropped on the next version of this package, unless the next version must be released while Elm 0.19 is still new (September 2018).
 
 ## [3.0.1] - 2017-02-25
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ format_all:
 	elm-format --yes .
 
 compile_lib: src/*.elm
-	elm make src/* --yes
+	elm make src/*
 
 compile_simple_example:
-	cd example/simple && elm make src/Main.elm --yes
+	cd example/simple && elm make src/Main.elm
 
 compile_editor_example:
-	cd example/editor && elm make src/Main.elm --yes
+	cd example/editor && elm make src/Main.elm

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: format_all compile_lib compile_simple_example compile_editor_example
 
 format_all:
-	elm-format-0.17 --yes .
+	elm-format --yes .
 
 compile_lib: src/*.elm
 	elm make src/* --yes

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.1",
+    "version": "3.0.2",
     "summary": "A highly configurable, efficiently rendered spinner component",
     "repository": "https://github.com/damienklinnert/elm-spinner.git",
     "license": "MIT",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,19 @@
+{
+    "version": "3.0.1",
+    "summary": "A highly configurable, efficiently rendered spinner component",
+    "repository": "https://github.com/damienklinnert/elm-spinner.git",
+    "license": "MIT",
+    "source-directories": [
+        "0.18-src"
+    ],
+    "exposed-modules": [
+        "Spinner"
+    ],
+    "dependencies": {
+        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "eskimoblood/elm-color-extra": "3.0.4 <= v < 4.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
This follows the pattern used in [elm-css](https://github.com/rtfeldman/elm-css) to maintain support for Elm 0.18 along with the new support for Elm 0.19.

The new version that supports Elm 0.19 will be `3.0.2`. The goal is that version `3.0.2` makes the Elm migration process easier for users of this package, since it will work in both 0.18 and 0.19. My intent is for that to be the final version that supports Elm 0.18, unless there are additional required changes in the near future.

Ideally, the next desired update to this package will not occur until after Elm 0.19 has wider adoption, and therefore dropping support for Elm 0.18 will not be a burden. That seems reasonable since this package has been stable for the last year.

**Background Info**
* https://discourse.elm-lang.org/t/version-package-updates-for-elm-0-19/1992
* https://github.com/rtfeldman/elm-css/pull/463
* https://github.com/rtfeldman/elm-css/pull/465